### PR TITLE
Paginate groceries

### DIFF
--- a/packages/CB-serverless-backend/api/groceries/getGroceries.js
+++ b/packages/CB-serverless-backend/api/groceries/getGroceries.js
@@ -7,7 +7,7 @@ import map from 'lodash/map';
 import awsConfigUpdate from '../../utils/awsConfigUpdate';
 import getErrorResponse from '../../utils/getErrorResponse';
 import getSuccessResponse from '../../utils/getSuccessResponse';
-import { GROCERIES_TABLE_NAME, GROCERIES_TABLE_GLOBAL_INDEX_NAME } from '../../dynamoDb/constants';
+import { GROCERIES_TABLE_NAME, GROCERIES_TABLE_GLOBAL_INDEX_NAME, PAGINATION_DEFAULT_OFFSET } from '../../dynamoDb/constants';
 
 awsConfigUpdate();
 
@@ -37,6 +37,7 @@ export const main = (event, context, callback) => {
     const category = event.queryStringParameters.category
     var params = {
 			...getBaseGroceriesParams(),
+			Limit: PAGINATION_DEFAULT_OFFSET,
 			IndexName: GROCERIES_TABLE_GLOBAL_INDEX_NAME,
       KeyConditionExpression: `#category = :categoryToFilter`,
 			ExpressionAttributeValues: {
@@ -48,7 +49,12 @@ export const main = (event, context, callback) => {
 
     queryPromise
       .then((data) => {
-        callback(null, getSuccessResponse(data))
+				console.log('Result set ' + JSON.stringify(data))
+				const responseData = {
+					Items: data.Items,
+					nextPageParams: data.LastEvaluatedKey ? `groceryId=${data.LastEvaluatedKey.groceryId}` : '',
+				}
+        callback(null, getSuccessResponse(responseData))
       })
       .catch((error) => {
         callback(null, getErrorResponse(500, 'Unable to fetch! Try again later'));

--- a/packages/CB-serverless-backend/dynamoDb/constants.js
+++ b/packages/CB-serverless-backend/dynamoDb/constants.js
@@ -2,4 +2,4 @@ export const GROCERIES_TABLE_NAME = 'grocery';
 export const GROCERIES_TABLE_GLOBAL_INDEX_NAME = 'GroceryCategoryIndex'
 export const CART_TABLE_NAME = 'cart';
 export const ORDERS_TABLE_NAME = 'orders';
-export const PAGINATION_DEFAULT_OFFSET = 10;
+export const PAGINATION_DEFAULT_OFFSET = 30;

--- a/packages/CB-serverless-backend/dynamoDb/constants.js
+++ b/packages/CB-serverless-backend/dynamoDb/constants.js
@@ -2,3 +2,4 @@ export const GROCERIES_TABLE_NAME = 'grocery';
 export const GROCERIES_TABLE_GLOBAL_INDEX_NAME = 'GroceryCategoryIndex'
 export const CART_TABLE_NAME = 'cart';
 export const ORDERS_TABLE_NAME = 'orders';
+export const PAGINATION_DEFAULT_OFFSET = 10;


### PR DESCRIPTION
Added pagination for fetching groceries filtered by `category`
The `/groceries?category=**` api will now return result in the below format
```javascript
{
    Items: [ ], // list of groceries
    nextPageParams: "nextPageIndex=87" // this field will have some value of next page of data is available else this will be empty
}
```

To fetch next page of data, just append the `nextPageParams` value to query string in url like `/groceries?category=eatable&nextPageIndex=87`

optionally the client can send limit for each page of result like 
`/groceries?category=eatable&nextPageIndex=87&limit=10`
